### PR TITLE
Added item search in stash

### DIFF
--- a/src/Lurker.UI/Helpers/KeyboardHelper.cs
+++ b/src/Lurker.UI/Helpers/KeyboardHelper.cs
@@ -54,6 +54,22 @@ namespace Lurker.UI.Helpers
             }
         }
 
+        /// <summary>
+        /// Simulates a search using Ctrl+F 
+        /// </summary>
+        /// <param name="searchTerm">The search term to use</param>
+        protected void Search(string searchTerm)
+        {
+            lock (CommandLock)
+            {                
+                Native.SetForegroundWindow(this._windowHandle);
+                System.Windows.Forms.SendKeys.SendWait("^F");
+
+                // We are using the interop since SendWait block mouse input.
+                this._simulator.Keyboard.TextEntry(searchTerm);
+            }
+        }
+
         #endregion
     }
 }

--- a/src/Lurker.UI/Helpers/PoeKeyboardHelper.cs
+++ b/src/Lurker.UI/Helpers/PoeKeyboardHelper.cs
@@ -62,6 +62,15 @@ namespace Lurker.UI.Helpers
             this.SendCommand($@"@{characterName} {message}");
         }
 
+        /// <summary>
+        /// Searches for an item in an opened stash
+        /// </summary>
+        /// <param name="itemName">The name of item to search for</param>
+        public void Search(string itemName)
+        {
+            base.Search(itemName);
+        }
+
         #endregion
     }
 }

--- a/src/Lurker.UI/ViewModels/TradeOfferViewModel.cs
+++ b/src/Lurker.UI/ViewModels/TradeOfferViewModel.cs
@@ -187,6 +187,12 @@ namespace Lurker.UI.ViewModels
             this.RemoveFromTradebar();
         }
 
+        public void SearchItem()
+        {
+            this._skipMainAction = true;
+            this._keyboardHelper.Search(this.ItemName);
+        }
+
         /// <summary>
         /// Invites the buyer.
         /// </summary>

--- a/src/Lurker.UI/Views/TradeOfferView.xaml
+++ b/src/Lurker.UI/Views/TradeOfferView.xaml
@@ -176,6 +176,40 @@
                                     </Style>
                                 </Button.Style>
                             </Button>
+                            <Button HorizontalAlignment="Center" Background="Green" VerticalAlignment="Top" Height="10" Width="20" cal:Message.Attach="[Event Click] = [Action SearchItem]" >
+                                <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="Button">
+                                                    <Border CornerRadius="0,0,10,10">
+                                                        <Border.Style>
+                                                            <Style TargetType="{x:Type Border}">
+                                                                <Setter Property="Background" Value="Gray"/>
+                                                                <Setter Property="Opacity" Value="0.25"/>
+                                                                <Style.Triggers>
+                                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                                        <Setter Property="Background" Value="Green" />
+                                                                        <Setter Property="Opacity" Value="0.75"/>
+                                                                    </Trigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Border.Style>
+                                                    </Border>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=IsMouseOver}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=IsMouseOver}" Value="False">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
                             <Button HorizontalAlignment="Right" Background="Red" Height="15" Width="15" cal:Message.Attach="[Event Click] = [Action Remove]" >
                                 <Button.Style>
                                     <Style TargetType="Button">


### PR DESCRIPTION
This PR adds item search functionality. Pressing the new green sub-button simulates Ctrl+F & types the item name. This automatically selects and fills the search box if a stash tab is currently open.

![image](https://user-images.githubusercontent.com/6319491/71779176-57fce900-2fb5-11ea-8640-db2c90943127.png)

Might render issue #10 obsolete.